### PR TITLE
Fix #1: Clarify the spec version to be adopted from WebVR CG

### DIFF
--- a/vr-wg-charter.html
+++ b/vr-wg-charter.html
@@ -172,7 +172,7 @@
             <dd>
               <p>This specification describes support for accessing virtual reality (VR) devices, including sensors and head-mounted displays on the Web.</p>
 
-              <p class="draft-status"><a href="https://w3c.github.io/webvr/">Adopted from WebVR CG</a></p>
+              <p class="draft-status"><a href="https://w3c.github.io/webvr/spec/latest/">"v2.0" adopted from WebVR CG</a></p>
 
               <p class="milestone"><b>Expected completion:</b> Q2 2018</p>
             </dd>
@@ -220,6 +220,13 @@
         <div>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
+            <dt><a href="https://www.w3.org/community/webvr/">WebVR Community Group</a></dt>
+            <dd>
+              The WebVR Community Group will provide the WebVR API "v2.0" seed
+              specification to begin the standards process. The WebVR API v1.1
+              maintenance is expected to continue in parallel in the Community
+              Group.
+            </dd>
             <dt><a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
             <dd>The Device and Sensors Working Group develops the Generic Sensor framework, which may provide valuable integration point with sensors that integrate with VR devices.</dd>
             <dt><a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a></dt>


### PR DESCRIPTION
- Clarify the version of the WebVR spec to be adopted
- Note WebVR CG and its relationship in Coordination

Fixes #1.

Please take a look @cvan @toji @dontcallmedom.